### PR TITLE
style: fix prettier formatting on client/src/App.js

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1462,8 +1462,8 @@ function App() {
           <div className='banner-message'>
             <span className='banner-icon'>🚨</span>
             <div className='banner-text'>
-              <strong>Domain Migration Notice:</strong> This domain (pr-reviewer.aswincloud.com) will
-              be inactive after <strong>November 2025</strong>. Please update your bookmarks to{' '}
+              <strong>Domain Migration Notice:</strong> This domain (pr-reviewer.aswincloud.com)
+              will be inactive after <strong>November 2025</strong>. Please update your bookmarks to{' '}
               <strong>pr-reviewer.aswincloud.com</strong>
             </div>
           </div>


### PR DESCRIPTION
Standalone formatting fix. `src/App.js` fails the repo's own `format:check` (prettier --check src/) on main — pre-existing debt, unrelated to any feature change. This is a 2-line word-wrap reflow, formatting-only, no logic change.

Unblocks the `all-checks-complete` gate so #70 (auto-approve caller) can merge green after this lands.