### PR TITLE
fix(ci): trigger on merge_group (merge-queue compatible)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  merge_group: {}          # run in the merge queue so the required
+                           # "all-checks-complete" gate is satisfied on the queued commit
 
 env:
   NODE_VERSION_MATRIX: '[18.x, 20.x, 22.x]'


### PR DESCRIPTION
pr-review-checker now has a merge queue; its `ci.yml` (producing the required `all-checks-complete` gate) didn't run on `merge_group`, so queued PRs would hang at AWAITING_CHECKS. Adds `merge_group: {}` trigger. Same fix already applied to .github/actionlint.